### PR TITLE
Include <atomic> in a few places to get this to build on Linux

### DIFF
--- a/src/J3D/Data/J3DModelData.cpp
+++ b/src/J3D/Data/J3DModelData.cpp
@@ -8,6 +8,7 @@
 #include "J3D/Material/J3DUniformBufferObject.hpp"
 
 #include <glad/glad.h>
+#include <atomic>
 
 std::atomic<uint16_t> J3DModelData::sInstanceIdSrc = 1;
 

--- a/src/J3D/Material/J3DMaterial.cpp
+++ b/src/J3D/Material/J3DMaterial.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <vector>
 #include <glad/glad.h>
+#include <atomic>
 
 std::atomic<uint16_t> J3DMaterial::sMaterialIdSrc = 1;
 


### PR DESCRIPTION
Seems like a case of a platorm-dependent recursive include getting what is needed from atomic on windows, but not on different implementations.